### PR TITLE
skip generating a UDP4 csum if the UDP6 csum is 0 and zero_csum_pass …

### DIFF
--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -1576,6 +1576,10 @@ void nat46_ipv6_input(struct sk_buff *old_skb) {
         }
       case NEXTHDR_UDP: {
         struct udphdr *udp = add_offset(ip6h, v6packet_l3size);
+        if ((udp->check == 0) && zero_csum_pass) {
+          /* zero checksum and the config to pass it is set - do nothing with it */
+          break;
+        }
         u16 sum1 = csum_ipv6_unmagic(nat46, &ip6h->saddr, &ip6h->daddr, l3_infrag_payload_len, NEXTHDR_UDP, udp->check);
         u16 sum2 = csum_tcpudp_remagic(v4saddr, v4daddr, l3_infrag_payload_len, NEXTHDR_UDP, sum1);
         udp->check = sum2;


### PR DESCRIPTION
…is set